### PR TITLE
cell references are case insensitive

### DIFF
--- a/lib/Spreadsheet/WriteExcel/Utility.pm
+++ b/lib/Spreadsheet/WriteExcel/Utility.pm
@@ -256,7 +256,7 @@ sub xl_cell_to_rowcol {
 
     my $cell = shift;
 
-    $cell =~ /(\$?)([A-Z]{1,3})(\$?)(\d+)/;
+    $cell =~ /(\$?)([A-Z]{1,3})(\$?)(\d+)/i;
 
     my $col_abs = $1 eq "" ? 0 : 1;
     my $col     = $2;


### PR DESCRIPTION
Cell references are case-insensitive:
http://en.wikipedia.org/wiki/Spreadsheet#Cell_reference

I was having a problem using the xl_inc_row function because it was not handling lowercase cell refs as I expected.
