### PR TITLE
Fix filter_column bug where filter is applied to the wrong column.

### DIFF
--- a/lib/Spreadsheet/WriteExcel/Worksheet.pm
+++ b/lib/Spreadsheet/WriteExcel/Worksheet.pm
@@ -5286,9 +5286,14 @@ sub _store_autofilters {
         # Skip if column doesn't have an active filter.
         next unless $self->{_filter_cols}->{$col};
 
-        # Retrieve the filter tokens and write the autofilter records.
+        # Retrieve the filter tokens
         my @tokens =  @{$self->{_filter_cols}->{$col}};
-        $self->_store_autofilter($col, @tokens);
+
+        # Filter columns are relative to the first column in the filter.
+        my $filter_col = $col - $col1;
+
+        # Write the autofilter records.
+        $self->_store_autofilter($filter_col, @tokens);
     }
 }
 


### PR DESCRIPTION
This bug appears when the auto-filter range does not start with the first column of the sheet.

Here is an example that demonstrates the issue: https://gist.github.com/2064779
