### PR TITLE
Avoid warnings triggered by undef values in calls to write_number

### DIFF
--- a/lib/Spreadsheet/WriteExcel/Worksheet.pm
+++ b/lib/Spreadsheet/WriteExcel/Worksheet.pm
@@ -2066,7 +2066,7 @@ sub write_number {
 
     my $row     = $_[0];                         # Zero indexed row
     my $col     = $_[1];                         # Zero indexed column
-    my $num     = $_[2];
+    my $num     = $_[2] // 0;                    # Avoid undef warnings
     my $xf      = _XF($self, $row, $col, $_[3]); # The cell format
 
     # Check that row and col are valid and store max and min values


### PR DESCRIPTION
```Warnings: Use of uninitialized value $num in pack at /usr/share/perl5/Spreadsheet/WriteExcel/Worksheet.pm line 2077.```

Users *should* not pass undef values here but actually, it's much easier to default them to 0 in the sub instead of covering each and every call.